### PR TITLE
"Access-Control-Allow-Credentials" header for all request types

### DIFF
--- a/src/java/com/brandseye/cors/CorsFilter.java
+++ b/src/java/com/brandseye/cors/CorsFilter.java
@@ -26,9 +26,10 @@ public class CorsFilter implements Filter {
             allowOriginRegex = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
         } else {
             headers.put("Access-Control-Allow-Origin", "*");
+            headers.put("Access-Control-Allow-Credentials", "true");
         }
 
-        headers.put("Access-Control-Allow-Credentials", "true");
+
         headers.put("Access-Control-Allow-Headers", "origin, authorization, accept, content-type, x-requested-with");
         headers.put("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, TRACE, OPTIONS");
         headers.put("Access-Control-Max-Age", "3600");
@@ -59,6 +60,7 @@ public class CorsFilter implements Filter {
                     checkOrigin(req, resp);
                 } else {
                     resp.addHeader("Access-Control-Allow-Origin", allowOrigin);
+                    resp.addHeader("Access-Control-Allow-Credentials", "true");
                 }
             }
         }
@@ -69,6 +71,7 @@ public class CorsFilter implements Filter {
         String origin = req.getHeader("Origin");
         if (origin != null && allowOriginRegex.matcher(origin).matches()) {
             resp.addHeader("Access-Control-Allow-Origin", origin);
+            resp.addHeader("Access-Control-Allow-Credentials", "true");
             return true;
         }
         return false;

--- a/test/unit/com/brandseye/cors/CorsFilterTest.groovy
+++ b/test/unit/com/brandseye/cors/CorsFilterTest.groovy
@@ -1,0 +1,94 @@
+package com.brandseye.cors
+
+import grails.test.mixin.TestFor
+
+import org.junit.Test
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockFilterConfig
+import org.springframework.mock.web.MockHttpServletRequest
+import grails.util.MockHttpServletResponse
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * @author Peter Schneider-Manzell
+ */
+@TestFor(CorsFilter)
+class CorsFilterTest {
+
+    CorsFilter underTest;
+    def minimalHeadersForAllAllowedRequests = ["Access-Control-Allow-Origin","Access-Control-Allow-Credentials"]
+    def defaultHeadersForAllowedOptionsRequest = [
+            "Access-Control-Allow-Origin",
+            "Access-Control-Allow-Credentials",
+            "Access-Control-Allow-Headers",
+            "Access-Control-Allow-Methods",
+            "Access-Control-Max-Age"
+    ]
+
+    public void testDefaultHeadersForOptionsRequestsWithoutOriginRegexp(){
+      def expectedHeadersForHttpMethods = [
+              'OPTIONS':defaultHeadersForAllowedOptionsRequest,
+              'GET':minimalHeadersForAllAllowedRequests,
+              'PUT':minimalHeadersForAllAllowedRequests,
+              'DELETE':minimalHeadersForAllAllowedRequests,
+              'POST':minimalHeadersForAllAllowedRequests
+      ]
+      String origin = "http://www.grails.org"
+      executeTest([:],expectedHeadersForHttpMethods,origin)
+    }
+
+    public void testDefaultHeadersForOptionsRequestsWithOriginRegexpAndAllowedOrigin(){
+        def expectedHeadersForHttpMethods = [
+                'OPTIONS':defaultHeadersForAllowedOptionsRequest,
+                'GET':minimalHeadersForAllAllowedRequests,
+                'PUT':minimalHeadersForAllAllowedRequests,
+                'DELETE':minimalHeadersForAllAllowedRequests,
+                'POST':minimalHeadersForAllAllowedRequests
+        ]
+        def filterInitParams = [:]
+        filterInitParams['allow.origin.regex'] = '.*grails.*'
+        String origin = "http://www.grails.org"
+        executeTest(filterInitParams,expectedHeadersForHttpMethods,origin)
+    }
+
+    public void testDefaultHeadersForOptionsRequestsWithOriginRegexpAndNotAllowedOrigin(){
+        def expectedHeadersForHttpMethods = [
+                'OPTIONS':[],
+                'GET':[],
+                'PUT':[],
+                'DELETE':[],
+                'POST':[]
+        ]
+        def filterInitParams = [:]
+        filterInitParams['allow.origin.regex'] = '.*grails.*'
+        String origin = "http://www.google.com"
+        executeTest(filterInitParams,expectedHeadersForHttpMethods,origin)
+    }
+
+
+    private void executeTest(Map<String,String> filterInitParams,Map<String,Set<String>> expectedHeadersForHttpMethods,String origin){
+        underTest = new CorsFilter()
+        MockFilterConfig filterConfig = new MockFilterConfig()
+        filterInitParams.entrySet().each {filterEntry->
+            filterConfig.addInitParameter(filterEntry.key,filterEntry.value)
+        }
+        underTest.init(filterConfig)
+
+
+        expectedHeadersForHttpMethods.entrySet().each {expectedHeadersForHttpMethod->
+            String httpMethod =  expectedHeadersForHttpMethod.key
+            Set<String> expectedHeaders = expectedHeadersForHttpMethod.value
+            HttpServletRequest req = new MockHttpServletRequest()
+            req.setMethod(httpMethod)
+            req.addHeader("Origin",origin)
+            HttpServletResponse res = new MockHttpServletResponse()
+            underTest.doFilter(req,res,new MockFilterChain())
+            assert  res.getHeaderNames().containsAll(expectedHeaders) : "Not all expected headers for request $httpMethod and origin $origin could be found! (expected: $expectedHeaders, got: ${res.getHeaderNames()})"
+            assert  res.getHeaderNames().size() == expectedHeaders.size() : "Header count for request $httpMethod and origin $origin not the expected header count! (expected: $expectedHeaders, got: ${res.getHeaderNames()})"
+
+        }
+    }
+
+}


### PR DESCRIPTION
Issue davidtinker/grails-cors#3 
- Added "Access-Control-Allow-Credentials" for all request types
- Added unit test for setting default headers
