### PR TITLE
Add grails-test-suite as test dependency to allow "grails test-app"

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -8,6 +8,10 @@ grails.project.dependency.resolution = {
         grailsCentral()
     }
 
+    dependencies {
+        test ":grails-test-suite-base:$grailsVersion"
+    }
+
     plugins {
         build(":release:2.0.4", ":rest-client-builder:1.0.2") {
             export = false


### PR DESCRIPTION
This should enable the execution of the tests of davidtinker/grails-cors#4 via console command "grails test-app"
