### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+
+jdk:
+  - openjdk7
+  - oraclejdk7
+
+before_install:
+ - sudo add-apt-repository -y ppa:groovy-dev/grails
+ - sudo apt-get update
+ - sudo apt-get -y install grails-ppa # not sure if necessary
+ - sudo apt-get install grails-2.1.1 # or the grails version.
+
+script: grails test-app


### PR DESCRIPTION
I've added a simple .travis.yaml file to enable travis builds.

I've managed to get my fork build by travis with these settings: https://travis-ci.org/pschneider-manzell/grails-cors

Currently the plugin is tested against openJDK and OracleJDK with grails 2.1.1

Steps to activate Travis (after merging pull request which activates the test dependencies):
- Go to travis-ci.org and sign in using your GitHub account
- Go to "Accounts"
- Sync your Repositories
- Click on the "Settings" icon for "grails-cors" to activate Webhook URL notifying Travis of new commits
- Activate "grails-cors" repository by switching the button to "on"
- Wait until the first build passes

To do:
- After travis-ci is activated you can add a build status image to the main README.md
