### PR TITLE
Added support for Access-Control-Expose-Headers in response.

### DIFF
--- a/CorsGrailsPlugin.groovy
+++ b/CorsGrailsPlugin.groovy
@@ -1,7 +1,7 @@
 import com.brandseye.cors.CorsFilter
 
 class CorsGrailsPlugin {
-    def version = "1.0.4"
+    def version = "1.0.5-SNAPSHOT"
     def grailsVersion = "2.0 > *"
     def title = "CORS Plugin"
     def author = "David Tinker"
@@ -34,6 +34,12 @@ class CorsGrailsPlugin {
                             'param-name'('header:' + k)
                             'param-value'(v)
                         }
+                    }
+                }
+                if (cfg.expose.headers) {
+                    'init-param' {
+                        'param-name'('expose.headers')
+                        'param-value'(cfg.expose.headers.toString())
                     }
                 }
             }


### PR DESCRIPTION
I'd like to thank you for this plugin; I was hitting the grails bug that wouldn't allow OPTIONS methods through to my controller when I found your solution.

For the work I'm doing, I needed to support the Access-Control-Expose-Headers in the response; this pull request contains my simple solution to add support as well as tighten the origin checking to be closer to my reading of the W3C spec, along with additional unit tests.

I'd greatly appreciate any feedback/discussion on the proposed changes (whether you agree with them or not).  If you disagree with them, or would like to see them implemented differently, please let me know, as I'd much prefer to see the feature added to your plugin than to maintain my own fork.

Thanks again
