### PR TITLE
Added support for Access-Control-Expose-Headers in the response.

### DIFF
--- a/CorsGrailsPlugin.groovy
+++ b/CorsGrailsPlugin.groovy
@@ -1,7 +1,7 @@
 import com.brandseye.cors.CorsFilter
 
 class CorsGrailsPlugin {
-    def version = "1.0.4"
+    def version = "1.0.5-SNAPSHOT"
     def grailsVersion = "2.0 > *"
     def title = "CORS Plugin"
     def author = "David Tinker"
@@ -34,6 +34,12 @@ class CorsGrailsPlugin {
                             'param-name'('header:' + k)
                             'param-value'(v)
                         }
+                    }
+                }
+                if (cfg.expose.headers) {
+                    'init-param' {
+                        'param-name'('expose.headers')
+                        'param-value'(cfg.expose.headers.toString())
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ Add a dependency to BuildConfig.groovy:
 
 The default configuration installs a servlet filter that adds the following headers to all OPTIONS requests:
 
-    Access-Control-Allow-Origin: *
+    Access-Control-Allow-Origin: <value of Origin header>
     Access-Control-Allow-Credentials: true
     Access-Control-Allow-Headers: origin, authorization, accept, content-type, x-requested-with
     Access-Control-Allow-Methods: GET, HEAD, POST, PUT, DELETE, TRACE, OPTIONS
     Access-Control-Max-Age: 3600
 
 The 'Access-Control-Allow-Origin' and 'Access-Control-Allow-Credentials' headers are also added to non-OPTIONS
-requests (GET, POST et al.).
+requests (GET, POST et al.).  If the plugin is configured to produce an 'Access-Control-Expose-Headers' header, it will be added to non-OPTIONS requests as well.
 
 These headers permit Javascript code loaded from anywhere to make AJAX calls to your application including specifying
 an 'Authorization' header (e.g. for Basic authentication). The browser will cache the results of the OPTIONS request
@@ -63,6 +63,10 @@ if you are happy with it. The CORS plugin implements this using a regex to match
 If 'Origin' header matches the regex then it is echoed back as 'Access-Control-Allow-Origin' otherwise no CORS
 headers are sent back to the client and the browser will deny the request.
 
+You can specify a comma-delimited list of response headers that should be exposed to the client:
+
+    cors.expose.headers = 'X-app-header1,X-app-header2'
+
 Client Performance Notes
 ------------------------
 
@@ -90,6 +94,7 @@ So if you can authenticate or whatever using query parameters instead of headers
 
 Changelog
 ---------
+1.0.5: Added Access-Control-Expose-Headers
 
 1.0.4: Added Access-Control-Allow-Credentials: true
 

--- a/src/java/com/brandseye/cors/CorsFilter.java
+++ b/src/java/com/brandseye/cors/CorsFilter.java
@@ -14,32 +14,39 @@ import java.util.regex.Pattern;
  */
 public class CorsFilter implements Filter {
 
-    private final Map<String, String> headers = new LinkedHashMap<String, String>();
+    private final Map<String, String> optionsHeaders = new LinkedHashMap<String, String>();
 
     private Pattern allowOriginRegex;
     private String allowOrigin;
+    private String exposeHeaders;
 
     public void init(FilterConfig cfg) throws ServletException {
         String regex = cfg.getInitParameter("allow.origin.regex");
         if (regex != null) {
             allowOriginRegex = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
         } else {
-            headers.put("Access-Control-Allow-Origin", "*");
+            optionsHeaders.put("Access-Control-Allow-Origin", "*");
         }
 
-        headers.put("Access-Control-Allow-Headers", "origin, authorization, accept, content-type, x-requested-with");
-        headers.put("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, TRACE, OPTIONS");
-        headers.put("Access-Control-Allow-Credentials", "true");
-        headers.put("Access-Control-Max-Age", "3600");
-
+        optionsHeaders.put("Access-Control-Allow-Headers", "origin, authorization, accept, content-type, x-requested-with");
+        optionsHeaders.put("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, TRACE, OPTIONS");
+        optionsHeaders.put("Access-Control-Max-Age", "3600");
         for (Enumeration<String> i = cfg.getInitParameterNames(); i.hasMoreElements(); ) {
             String name = i.nextElement();
             if (name.startsWith("header:")) {
-                headers.put(name.substring(7), cfg.getInitParameter(name));
+                optionsHeaders.put(name.substring(7), cfg.getInitParameter(name));
             }
         }
 
-        allowOrigin = headers.get("Access-Control-Allow-Origin");
+        //maintained for backward compatibility on how to set allowOrigin if not
+        //using a regex
+        allowOrigin = optionsHeaders.get("Access-Control-Allow-Origin");
+        //since all methods now go through checkOrigin() to apply the Access-Control-Allow-Origin
+        //header, and that header should have a single value of the requesting Origin since
+        //Access-Control-Allow-Credentials is always true, we remove it from the options headers
+        optionsHeaders.remove("Access-Control-Allow-Origin");
+
+        exposeHeaders = cfg.getInitParameter("expose.headers");
     }
 
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
@@ -48,17 +55,14 @@ public class CorsFilter implements Filter {
             HttpServletRequest req = (HttpServletRequest)request;
             HttpServletResponse resp = (HttpServletResponse)response;
             if ("OPTIONS".equals(req.getMethod())) {
-                if (allowOriginRegex == null || checkOrigin(req, resp)) {
-                    for (Map.Entry<String, String> e : headers.entrySet()) {
+                if (checkOrigin(req, resp)) {
+                    for (Map.Entry<String, String> e : optionsHeaders.entrySet()) {
                         resp.addHeader(e.getKey(), e.getValue());
                     }
                 }
-            } else {
-                if (allowOriginRegex != null) {
-                    checkOrigin(req, resp);
-                } else {
-                    resp.addHeader("Access-Control-Allow-Origin", allowOrigin);
-                    resp.addHeader("Access-Control-Allow-Credentials", "true");
+            } else if (checkOrigin(req, resp)) {
+                if (exposeHeaders != null) {
+                    resp.addHeader("Access-Control-Expose-Headers", exposeHeaders);
                 }
             }
         }
@@ -67,12 +71,26 @@ public class CorsFilter implements Filter {
 
     private boolean checkOrigin(HttpServletRequest req, HttpServletResponse resp) {
         String origin = req.getHeader("Origin");
-        if (origin != null && allowOriginRegex.matcher(origin).matches()) {
+        if (origin == null) {
+            //no origin; per W3C spec, terminate further processing for both preflight and actual requests
+            return false;
+        }
+
+        boolean matches = false;
+        //check if using regex to match origin
+        if (allowOriginRegex != null) {
+            matches = allowOriginRegex.matcher(origin).matches();
+        } else if (allowOrigin != null) {
+            matches = allowOrigin.equals("*") || allowOrigin.equals(origin);
+        }
+
+        if (matches) {
             resp.addHeader("Access-Control-Allow-Origin", origin);
             resp.addHeader("Access-Control-Allow-Credentials", "true");
             return true;
+        } else {
+            return false;
         }
-        return false;
     }
 
     public void destroy() {

--- a/test/unit/com/brandseye/cors/CorsFilterTest.groovy
+++ b/test/unit/com/brandseye/cors/CorsFilterTest.groovy
@@ -66,6 +66,53 @@ class CorsFilterTest {
         executeTest(filterInitParams,expectedHeadersForHttpMethods,origin)
     }
 
+    public void testDefaultHeadersForOptionsRequestsWithoutOriginRegexpAndNotAllowedOrigin(){
+        def expectedHeadersForHttpMethods = [
+                'OPTIONS':[],
+                'GET':[],
+                'PUT':[],
+                'DELETE':[],
+                'POST':[]
+        ]
+        def filterInitParams = [:]
+        filterInitParams['header:Access-Control-Allow-Origin'] = 'http://www.grails.org'
+        String origin = "http://www.google.com"
+        executeTest(filterInitParams,expectedHeadersForHttpMethods,origin)
+    }
+
+    public void testExposedHeaders() {
+        def headers = ["Access-Control-Allow-Origin","Access-Control-Allow-Credentials","Access-Control-Expose-Headers"]
+        def expectedHeadersForHttpMethods = [
+                'OPTIONS':defaultHeadersForAllowedOptionsRequest,
+                'GET':headers,
+                'PUT':headers,
+                'DELETE':headers,
+                'POST':headers
+        ]
+        def filterInitParams = [:]
+        filterInitParams['allow.origin.regex'] = '.*grails.*'
+        filterInitParams['expose.headers'] = "X-custom-header"
+        String origin = "http://www.grails.org"
+        executeTest(filterInitParams,expectedHeadersForHttpMethods,origin)
+    }
+
+    public void testValueOfExposedHeaders() {
+        def underTest = new CorsFilter()
+        def expected = 'X-custom-header1,X-custom-header2'
+        MockFilterConfig filterConfig = new MockFilterConfig()
+        filterConfig.addInitParameter('allow.origin.regex','.*grails.*')
+        filterConfig.addInitParameter('expose.headers',expected)
+        underTest.init(filterConfig)
+
+        HttpServletRequest req = new MockHttpServletRequest()
+        req.setMethod("PUT")
+        req.addHeader("Origin",'http://www.grails.org')
+        HttpServletResponse res = new MockHttpServletResponse()
+        underTest.doFilter(req,res,new MockFilterChain())
+        assert  res.getHeader('Access-Control-Expose-Headers').equals('X-custom-header1,X-custom-header2') : "Access-Control-Expose-Headers, expected ${expected}, got ${res.getHeader('Access-Control-Expose-Headers')}"
+
+    }
+
 
     private void executeTest(Map<String,String> filterInitParams,Map<String,Set<String>> expectedHeadersForHttpMethods,String origin){
         underTest = new CorsFilter()
@@ -86,6 +133,16 @@ class CorsFilterTest {
             underTest.doFilter(req,res,new MockFilterChain())
             assert  res.getHeaderNames().containsAll(expectedHeaders) : "Not all expected headers for request $httpMethod and origin $origin could be found! (expected: $expectedHeaders, got: ${res.getHeaderNames()})"
             assert  res.getHeaderNames().size() == expectedHeaders.size() : "Header count for request $httpMethod and origin $origin not the expected header count! (expected: $expectedHeaders, got: ${res.getHeaderNames()})"
+
+            //check that the Access-Control-Allow-Credentials is always single-valued
+            if (res.getHeaderNames().contains('Access-Control-Allow-Credentials')) {
+                assert res.getHeaders('Access-Control-Allow-Credentials').size() == 1
+            }
+            //check that the Access-Control-Allow-Origin is always single-valued,
+            //since we always set Access-Control-Allow-Credentials
+            if (res.getHeaderNames().contains('Access-Control-Allow-Origin')) {
+                assert res.getHeaders('Access-Control-Allow-Origin').size() == 1
+            }
 
         }
     }


### PR DESCRIPTION
I'd like to thank you for this plugin; I was hitting the grails bug that wouldn't allow OPTIONS methods through to my controller when I found your solution.

For the work I'm doing, I needed to support the Access-Control-Expose-Headers in the response; this pull request contains my simple solution to add support as well as tighten the origin checking to be closer to my reading of the W3C spec, along with additional unit tests.

I'd greatly appreciate any feedback/discussion on the proposed changes (whether you agree with them or not).  If you disagree with them, or would like to see them implemented differently, please let me know, as I'd much prefer to see the feature added to your plugin than to maintain my own fork.

The only potential non-backward compatible change I have introduced is that I am checking that the Origin header exists and is a match on all requests (per my read of the W3C CORS spec), where as previously, the filter would add CORS headers to the response for any request if the origin regex was not being used.  The filter will now always set the value of the Origin header (if accepted as a match) in the Access-Control-Allow-Origin response header.  (Again, my read of the W3C spec that requires that behavior when returning Access-Control-Allow-Credentials with a true value.)

Note that I set the version to 1.0.5-SNAPSHOT for my own development.

Looking forward to your comments.

Thanks again for the plugin,
Shane Riddell
