### PR TITLE
application variable is not available in the context of the call of getW...

### DIFF
--- a/CorsGrailsPlugin.groovy
+++ b/CorsGrailsPlugin.groovy
@@ -77,8 +77,6 @@ class CorsGrailsPlugin {
     }
 
     def getWebXmlFilterOrder() {
-        def cfg = application.config.cors
-        if (cfg.containsKey('enabled') && !cfg.enabled) return
         def FilterManager = getClass().getClassLoader().loadClass('grails.plugin.webxml.FilterManager')
         // Be before the earliest Resource filter.
         ['cors-headers': FilterManager.DEFAULT_POSITION - 400]


### PR DESCRIPTION
...ebXmlFilterOrder

With the previous code the webxml plugin does not recognize the cors plugin as having a webXmlFilterOrder property.
